### PR TITLE
PB-40626 Fix str_getcsv function deprecation

### DIFF
--- a/src/Lib/PermissionMatrix.php
+++ b/src/Lib/PermissionMatrix.php
@@ -163,7 +163,9 @@ class PermissionMatrix
     private static function _loadCsv($file, $orientation = 'resource')
     {
         $matrix = [];
-        $csv = array_map('str_getcsv', file($file));
+        foreach (file($file) as $chunks) {
+            $csv[] = str_getcsv($chunks, separator: ',', enclosure: '"', escape: '');
+        }
 
         // Extract the csv header
         $header = array_shift($csv);


### PR DESCRIPTION
Improve PHP 8.4 compatibility by fixing "deprecated: 8192 :: str_getcsv(): the $escape parameter must be provided as its default value will change" error